### PR TITLE
refactor(error.service): clean up whitespace in clearCircuitBreakerCache function

### DIFF
--- a/src/main/system-analysis/service/error.service.ts
+++ b/src/main/system-analysis/service/error.service.ts
@@ -206,14 +206,14 @@ export const withErrorRecovery = <T>(
 /**
  * Clears all cached circuit breakers
  * Useful for testing or when you want to reset all circuit breaker states
- * 
+ *
  * Note: WeakMap doesn't have a clear() method, so we recreate the WeakMap instance
  * to effectively clear it. This ensures both cache layers are properly reset.
  */
 export const clearCircuitBreakerCache = (): void => {
   // Clear the composite cache (Map)
   compositeCircuitBreakerCache.clear();
-  
+
   // Clear the WeakMap cache by recreating it
   // WeakMap doesn't have a clear() method, so this is the standard approach
   circuitBreakerCache = new WeakMap<AsyncFunction, CircuitBreaker>();


### PR DESCRIPTION
- Removed unnecessary whitespace in the clearCircuitBreakerCache function for improved code readability.
- Maintained existing functionality and documentation clarity regarding the cache clearing process.