### PR TITLE
refactor(App): separate useEffect for connectedPeer logic

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -116,11 +116,6 @@ export default function App() {
       setAnalysis(analysisResult);
       setIsAnalyzing(false);
       setAnalysisProgress(null);
-
-      // Automatically open File Manager if we have a connected peer
-      if (connectedPeer) {
-        setShowFileSelection(true);
-      }
     });
 
     window.electronAPI.onAnalysisError((error: string) => {
@@ -130,7 +125,15 @@ export default function App() {
     });
 
     return () => {};
-  }, [connectedPeer]);
+  }, []); // Empty dependency array - run only once on mount
+
+  // Separate useEffect for handling connectedPeer-dependent logic
+  useEffect(() => {
+    // Automatically open File Manager if we have both analysis and a connected peer
+    if (connectedPeer && analysis) {
+      setShowFileSelection(true);
+    }
+  }, [connectedPeer, analysis]);
 
   const handleAnalyze = async () => {
     setIsAnalyzing(true);


### PR DESCRIPTION
- Moved the logic for automatically opening the File Manager into a separate useEffect that depends on both connectedPeer and analysis.
- Cleaned up the original useEffect to run only once on component mount, improving clarity and maintainability of the code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved handling of UI updates related to peer connection and analysis results for better reliability and clarity. The File Manager now opens automatically only when both a peer is connected and an analysis result is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->